### PR TITLE
Contributor list flow content model fix

### DIFF
--- a/index.css
+++ b/index.css
@@ -54,6 +54,10 @@ article > header > h1 {
     font-size: 2em;
 }
 
+article > header > dl#credits > dd > ul {
+    pading-left: unset;
+}
+
 a {
     color: var(--color-accent-primary);
 }
@@ -114,3 +118,4 @@ ul.contents > li.directory::before {
 ul.contents > li.document::before {
 	content: "📄\FE0F"; /* page facing up followed by VS-16 */
 }
+

--- a/index.xhtml
+++ b/index.xhtml
@@ -64,15 +64,17 @@
 		<article>
 			<header>
 				<h1>Game rulesets</h1>
-				<p>
-					Contributors:
-					<ul>
-						<li>Dan Leonard</li>
-						<li>Mac Bolz</li>
-						<li>Kevin Thompson</li>
-						<li>Alex Mackowiak</li>
-					</ul>
-				</p>
+				<dl id="credits">
+					<dt>Contributors</dt>
+					<dd>
+						<ul>
+							<li>Dan Leonard</li>
+							<li>Mac Bolz</li>
+							<li>Kevin Thompson</li>
+							<li>Alex Mackowiak</li>
+						</ul>
+					</dd>
+				</dl>
 			</header>
 			<h2>Directory contents</h2>
 			<ul class="contents">


### PR DESCRIPTION
Changing the credit listing to use a description list to encapsulate the unordered list rather than a `<p>` tag